### PR TITLE
lintswitch.vim should check for +python feature

### DIFF
--- a/plugin/lintswitch.vim
+++ b/plugin/lintswitch.vim
@@ -4,6 +4,11 @@
 " Copy this file into ./vim/plugin/
 " Make sure the lintswitch server is running.
 
+if !has('python')
+"     echo 'Error: lintswitch.vim requires Vim to be compiled with +python'
+    finish
+endif
+
 function! LintSwitch()
     python << END
 import vim


### PR DESCRIPTION
to reproduce:
1. checkout vim from source, build it with no python support
2. `vi foo.py`
3.  see losta errors!!1
